### PR TITLE
Compatibility fix for Swift 2.1

### DIFF
--- a/Pod/Classes/ExpandableColumnLayout.swift
+++ b/Pod/Classes/ExpandableColumnLayout.swift
@@ -194,12 +194,14 @@ public class ExpandableColumnLayout: UICollectionViewLayout {
                 if updateItem.updateAction == UICollectionUpdateAction.Insert || updateItem.updateAction == UICollectionUpdateAction.Delete {
                     let indexPath = updateItem.updateAction == UICollectionUpdateAction.Insert ? updateItem.indexPathAfterUpdate : updateItem.indexPathBeforeUpdate;
                     
-                    if indexPath.item == NSNotFound {
-                        sectionUpdates[indexPath] = updateItem;
-                        earliestSectionUpdate = self.findEarliestSectionUpdate(earliestSectionUpdate, candidateUpdate: indexPath.section);
-                    } else {
-                        itemUpdates[indexPath] = updateItem;
-                        earliestItemUpdate = self.findEarliestItemUpdate(earliestItemUpdate, candidateUpdate: indexPath);
+                    if(indexPath != nil) {
+                        if indexPath!.item == NSNotFound {
+                            sectionUpdates[indexPath!] = updateItem;
+                            earliestSectionUpdate = self.findEarliestSectionUpdate(earliestSectionUpdate, candidateUpdate: indexPath!.section);
+                        } else {
+                            itemUpdates[indexPath!] = updateItem;
+                            earliestItemUpdate = self.findEarliestItemUpdate(earliestItemUpdate, candidateUpdate: indexPath!);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
http://stackoverflow.com/a/29374058

"All your optionals need to be unwrapped. So lvt should become lvt!

Word of Caution Unwrapping an optional which doesn't have a value will thrown an exception. So it might be a good idea to make sure your lvt isn't nil.

if (lvt != nil)" 
- Shamas S(http://stackoverflow.com/users/1891327/shamas-s)
